### PR TITLE
Create our first endpoint to create a course

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 /pkg/
 /spec/reports/
 /tmp/
+
+# Rubocop caching file
+.rubocop-https*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+inherit_from:
+  - https://raw.githubusercontent.com/lessonly/rubocop-default-configuration/master/.rubocop.yml

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,53 @@
+PATH
+  remote: .
+  specs:
+    degreed (0.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    ast (2.4.2)
+    crack (0.4.5)
+      rexml
+    hashdiff (1.0.1)
+    minitest (5.14.4)
+    parallel (1.20.1)
+    parser (3.0.1.1)
+      ast (~> 2.4.1)
+    public_suffix (4.0.6)
+    rainbow (3.0.0)
+    rake (12.3.3)
+    regexp_parser (2.1.1)
+    rexml (3.2.5)
+    rubocop (1.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.7.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.7.0)
+      parser (>= 3.0.1.1)
+    ruby-progressbar (1.11.0)
+    unicode-display_width (2.0.0)
+    webmock (3.13.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  degreed!
+  minitest (~> 5.0)
+  rake (~> 12.0)
+  rubocop
+  webmock
+
+BUNDLED WITH
+   2.1.4

--- a/degreed.gemspec
+++ b/degreed.gemspec
@@ -3,20 +3,19 @@ require_relative 'lib/degreed/version'
 Gem::Specification.new do |spec|
   spec.name          = "degreed"
   spec.version       = Degreed::VERSION
-  spec.authors       = ["Ross Reinhardt"]
+  spec.authors       = ["Ross Reinhardt", "Brittany Hutter"]
   spec.email         = ["rreinhardt9@gmail.com"]
 
-  spec.summary       = %q{TODO: Write a short summary, because RubyGems requires one.}
-  spec.description   = %q{TODO: Write a longer description or delete this line.}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.summary       = %q{API wrapper for Degreed}
+  spec.homepage      = "https://github.com/lessonly/degreed"
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
 
   spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
-  spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
+  spec.metadata["source_code_uri"] = "https://github.com/lessonly/degreed"
+  spec.metadata["changelog_uri"] = "https://github.com/lessonly/degreed/blob/main/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -26,4 +25,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+
+  spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "webmock"
 end

--- a/lib/degreed.rb
+++ b/lib/degreed.rb
@@ -1,6 +1,67 @@
-require "degreed/version"
+# frozen_string_literal: true
 
+require "json"
+require "degreed/version"
+require "degreed/request"
+require "degreed/response"
+require "degreed/content/courses"
+
+# Client for the Degreed API
 module Degreed
-  class Error < StandardError; end
-  # Your code goes here...
+  # Access the current configuration
+  def configuration
+    @configuration ||= Configuration.new
+  end
+  module_function :configuration
+
+  # Alias so that we can refer to configuration as config
+  def config
+    configuration
+  end
+  module_function :config
+
+  # Configure the library
+  #
+  # @yieldparam [Degreed::Configuration] current_configuration
+  #
+  # @example
+  #   Degreed.configure do |config|
+  #     config.base_url = "www.foobar.com"
+  #   end
+  #
+  # @yieldreturn [Degreed::Configuration]
+  def configure
+    yield configuration
+  end
+  module_function :configure
+
+  # Configuration holds the current configuration for the Degreed
+  # and provides defaults
+  class Configuration
+    attr_accessor :base_url
+
+    def initialize(args = {})
+      @base_url = args.fetch(:base_url, "https://api.degreed.com/api/v2")
+    end
+  end
+
+  # Base level client for Degreed.
+  # You can access other sub clients through this class if desired.
+  #
+  # @param token [String] valid oauth token
+  #
+  # @example Accessing courses
+  #   Degreed::Client.new(token: "token").courses
+  class Client
+    def initialize(token: nil)
+      @token = token
+    end
+
+    # Access the courses client
+    #
+    # @return [Degreed::Content::Courses]
+    def courses
+      Content::Courses.new(token: @token)
+    end
+  end
 end

--- a/lib/degreed/content/courses.rb
+++ b/lib/degreed/content/courses.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Degreed
+  module Content
+    # Methods for calling Degreed endpoints for creating, managing, and
+    # retrieving courses.
+    #
+    # @see https://api.degreed.com/docs/#content-courses
+    class Courses
+      def initialize(token:)
+        @token = token
+      end
+
+      # Create a course
+      #
+      # @see https://api.degreed.com/docs/#create-a-new-course
+      #
+      # @param title [String]
+      # @param external_id [String, #to_s]
+      # @param url [String]
+      # @param duration [Integer, #to_i]
+      # @param duration_type [String]
+      #   Accepted values: Seconds, Minutes, Hours, or Days
+      # @param summary [String] Optional (default: nil)
+      #
+      # @return [Degreed::Response]
+      def create(title:, external_id:, url:, duration:, duration_type:, **kwargs)
+        request.post(
+          content_courses_url,
+          body: {
+            title: title,
+            summary: kwargs.fetch(:summary, nil),
+            "external-id": String(external_id),
+            url: url,
+            duration: Integer(duration),
+            "duration-type": duration_type
+          }
+        )
+      end
+
+      # List courses
+      #
+      # @see https://api.degreed.com/docs/#get-all-courses
+      #
+      # @param external_id [String, #to_s] Optional filter
+      #
+      # @return [Degreed::Response]
+      def all(external_id: nil)
+        params = {}
+        params["filter[external_id]"] = String(external_id) if external_id
+
+        request.get(content_courses_url, params: params)
+      end
+
+      private
+
+      def request
+        Request.new(token: @token)
+      end
+
+      def content_courses_url
+        "#{Degreed.config.base_url}/content/courses"
+      end
+    end
+  end
+end

--- a/lib/degreed/request.rb
+++ b/lib/degreed/request.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "net/http"
+
+module Degreed
+  # Request encapsulates the specifics of making requests to the Degreed API
+  # for the common http verbs.
+  class Request
+    def initialize(token:)
+      @token = token
+    end
+
+    # Get request
+    #
+    # @param uri [String]
+    # @param params [Hash] query params for this request
+    #
+    # @return [Degreed::Response]
+    def get(uri, params: {})
+      uri = URI.parse(uri)
+      uri.query = URI.encode_www_form(params) if params
+      req = Net::HTTP::Get.new(uri)
+      req["Authorization"] = "Bearer #{@token}" if @token
+
+      res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+        http.request(req)
+      end
+
+      Response.new(res).raise_on_error
+    end
+
+    # Post request
+    #
+    # @param uri [String]
+    # @param body [#to_json] post body
+    #
+    # @return [Degreed::Response]
+    def post(uri, body: nil)
+      uri = URI.parse(uri)
+      req = Net::HTTP::Post.new(uri)
+      req["Authorization"] = "Bearer #{@token}"
+      req.body = body.to_json if body
+      req["Content-Type"] = "application/json"
+
+      res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+        http.request(req)
+      end
+
+      Response.new(res).raise_on_error
+    end
+  end
+end

--- a/lib/degreed/response.rb
+++ b/lib/degreed/response.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "forwardable"
+
+module Degreed
+  class Error < StandardError; end
+
+  class DegreedError < Error; end
+
+  class HTTPClientError < DegreedError; end
+
+  class HTTPServerError < DegreedError; end
+
+  class HTTPBadRequest < HTTPClientError; end
+
+  class HTTPUnauthorized < HTTPClientError; end
+
+  class HTTPForbidden < HTTPClientError; end
+
+  # Response represents a response from Degreed.
+  #
+  # It is returned when using methods in Request.
+  # @see Degreed::Request
+  class Response
+    attr_reader :raw_response
+
+    extend Forwardable
+    # def_delegators :@raw_response, :code
+
+    def initialize(response)
+      @raw_response = response
+    end
+
+    # Was the response code 2xx
+    #
+    # @return [Boolean]
+    def success?
+      @raw_response.is_a?(Net::HTTPSuccess)
+    end
+
+    def code
+      Integer(@raw_response.code)
+    end
+
+    # Body of the request
+    #
+    # @return [Hash] request body
+    def body
+      return {} if @raw_response.body.strip.empty?
+
+      JSON.parse(@raw_response.body)
+    end
+
+    def raise_on_error
+      exception_class =
+        case code
+        when 400 then HTTPBadRequest
+        when 401 then HTTPUnauthorized
+        when 403 then HTTPForbidden
+        when (400...500) then HTTPClientError
+        when (500...600) then HTTPServerError
+        end
+
+      raise exception_class, "HTTP code: #{code}, message: #{body.dig('error', 'message')}" if exception_class
+
+      self
+    end
+  end
+end

--- a/test/degreed/content/courses_test.rb
+++ b/test/degreed/content/courses_test.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Degreed
+  module Content
+    class CoursesTest < Minitest::Test
+      def test_create_a_course
+        create_request = stub_request(:post, "https://api.degreed.com/api/v2/content/courses")
+          .with(
+            headers: {
+              "Authorization" => "Bearer someoauthtoken",
+              "content-type" => "application/json"
+            },
+            body: {
+              title: "New Course",
+              summary: "A Summary",
+              "external-id": "arstaroisen",
+              url: "https://dev.lessonly.com",
+              duration: 200,
+              "duration-type": "Seconds"
+            }.to_json
+          )
+          .to_return(
+            status: 201,
+            body: <<~JSON
+              {
+                "data": {
+                  "type": "content/courses",
+                  "id": "foo",
+                  "attributes": {
+                    "provider-code": null,
+                    "external-id": "arstaroisen",
+                    "degreed-url": "https://degreed.com/courses/?d=V9RVZY40PJ",
+                    "title": "New Course",
+                    "summary": "A Summary",
+                    "url": "https://dev.lessonly.com",
+                    "obsolete": false,
+                    "image-url": null,
+                    "language": null,
+                    "duration": 200,
+                    "duration-type": "Seconds",
+                    "cost-units": 0.0,
+                    "cost-unit-type": null,
+                    "format": null,
+                    "difficulty": null,
+                    "video-url": null,
+                    "created-at": "0001-01-01T00:00:00",
+                    "modified-at": "0001-01-01T00:00:00"
+                  },
+                  "links": {
+                    "self": "/content/courses/foo"
+                  }
+                }
+              }
+            JSON
+          )
+
+        response = Degreed::Content::Courses.new(token: "someoauthtoken").create(
+          title: "New Course",
+          summary: "A Summary",
+          external_id: "arstaroisen",
+          url: "https://dev.lessonly.com",
+          duration: 200,
+          duration_type: "Seconds"
+        )
+
+        assert_requested create_request
+        assert_equal 201, response.code
+        assert_equal "New Course", response.body.dig("data", "attributes", "title")
+      end
+
+      def test_get_courses_filtered_by_external_id
+        courses_request = stub_request(:get, "https://api.degreed.com/api/v2/content/courses")
+          .with(
+            headers: { "Authorization" => "Bearer someoauthtoken" },
+            query: {
+              "filter[external_id]": "1234"
+            }
+          )
+          .to_return(
+            status: 200,
+            body: <<~JSON
+              {
+                "links": {
+                  "self": "https://api.degreed.com/api/v2/content/courses",
+                  "next": "https://api.degreed.com/api/v2/content/courses?next=OomeEL"
+                },
+                "data": {
+                  "type": "content/courses",
+                  "id": "foo",
+                  "attributes": {
+                    "provider-code": null,
+                    "external-id": "arstaroisen",
+                    "degreed-url": "https://degreed.com/courses/?d=V9RVZY40PJ",
+                    "title": "New Course",
+                    "summary": "A Summary",
+                    "url": "https://dev.lessonly.com",
+                    "obsolete": false,
+                    "image-url": null,
+                    "language": null,
+                    "duration": 200,
+                    "duration-type": "Seconds",
+                    "cost-units": 0.0,
+                    "cost-unit-type": null,
+                    "format": null,
+                    "difficulty": null,
+                    "video-url": null,
+                    "created-at": "0001-01-01T00:00:00",
+                    "modified-at": "0001-01-01T00:00:00"
+                  },
+                  "links": {
+                    "self": "https://api.degreed.com/api/v2/content/courses/foo"
+                  }
+                }
+              }
+            JSON
+          )
+
+        response = Degreed::Content::Courses.new(token: "someoauthtoken").all(
+          external_id: "1234"
+        )
+
+        assert_requested courses_request
+        assert_equal 200, response.code
+        assert_equal "New Course", response.body.dig("data", "attributes", "title")
+      end
+    end
+  end
+end

--- a/test/degreed_test.rb
+++ b/test/degreed_test.rb
@@ -4,8 +4,4 @@ class DegreedTest < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::Degreed::VERSION
   end
-
-  def test_it_does_something_useful
-    assert false
-  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,8 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "degreed"
 
 require "minitest/autorun"
+require "minitest/pride"
+require "webmock/minitest"


### PR DESCRIPTION
This also creates some basic utilities nice request and response
objects, as well as gem configuration.

### Two New Endpoints!
1) **create**  - To create new course, to be used in situations where one does not already exist for a piece of content
2) **all** - To retrieve courses from Degreed, with an optional filter of `external_id`

Co-authored-by: Brittany Hutter <brittany.hutter@lessonly.com>
