### PR TITLE
Mark existing content as NOT obsolete when made public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@
 
 # Rubocop caching file
 .rubocop-https*
+
+
+# dont add byebug files
+.byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,5 @@ gemspec
 
 gem "rake", "~> 12.0"
 gem "minitest", "~> 5.0"
+
+gem "byebug", "~> 11.1", :group => :development

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,3 @@ gemspec
 
 gem "rake", "~> 12.0"
 gem "minitest", "~> 5.0"
-
-gem "byebug", "~> 11.1", :group => :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
+    byebug (11.1.3)
     crack (0.4.5)
       rexml
     hashdiff (1.0.1)
@@ -43,6 +44,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  byebug (~> 11.1)
   degreed!
   minitest (~> 5.0)
   rake (~> 12.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  byebug (~> 11.1)
+  byebug
   degreed!
   minitest (~> 5.0)
   rake (~> 12.0)
@@ -52,4 +52,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.1.4
+   2.2.6

--- a/degreed.gemspec
+++ b/degreed.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "webmock"
+  spec.add_development_dependency "byebug"
 end

--- a/lib/degreed/content/courses.rb
+++ b/lib/degreed/content/courses.rb
@@ -11,6 +11,10 @@ module Degreed
         @token = token
       end
 
+      def dasherize(underscored_word)
+        underscored_word.tr("_", "-")
+      end
+
       # Create a course
       #
       # @see https://api.degreed.com/docs/#create-a-new-course
@@ -52,6 +56,43 @@ module Degreed
         request.get(content_courses_url, params: params)
       end
 
+      # Update course
+      #
+      # @see https://api.degreed.com/docs/#update-a-specific-course
+      #
+      # @param title [String]
+      # @param external_id [String, #to_s]
+      # @param url [String]
+      # @param duration [Integer, #to_i]
+      # @param duration_type [String]
+      #   Accepted values: Seconds, Minutes, Hours, or Days
+      # @param summary [String] Optional (default: nil)
+      #
+      # @return [Degreed::Response]
+      def update(id:, **kwargs)
+        allowed_attributes = %w[
+          title
+          url
+          duration
+          duration-type
+          obsolete
+          summary
+        ]
+        updated_attrs = kwargs
+          .transform_keys(&:to_s)
+          .transform_keys { |key| dasherize(key) }
+          .filter { |key| allowed_attributes.include? key }
+        body = {
+          data: {
+            type: "content/courses",
+            id: id,
+            attributes: updated_attrs
+          }
+        }
+
+        request.patch(content_course_url(id), body: body)
+      end
+
       private
 
       def request
@@ -60,6 +101,10 @@ module Degreed
 
       def content_courses_url
         "#{Degreed.config.base_url}/content/courses"
+      end
+
+      def content_course_url(id)
+        "#{content_courses_url}/#{id}"
       end
     end
   end

--- a/lib/degreed/request.rb
+++ b/lib/degreed/request.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "net/http"
-require "byebug"
 
 module Degreed
   # Request encapsulates the specifics of making requests to the Degreed API

--- a/lib/degreed/request.rb
+++ b/lib/degreed/request.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "net/http"
+require "byebug"
 
 module Degreed
   # Request encapsulates the specifics of making requests to the Degreed API
@@ -38,6 +39,26 @@ module Degreed
     def post(uri, body: nil)
       uri = URI.parse(uri)
       req = Net::HTTP::Post.new(uri)
+      req["Authorization"] = "Bearer #{@token}"
+      req.body = body.to_json if body
+      req["Content-Type"] = "application/json"
+
+      res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+        http.request(req)
+      end
+
+      Response.new(res).raise_on_error
+    end
+
+    # Patch request
+    #
+    # @param uri [String]
+    # @param body [#to_json] post body
+    #
+    # @return [Degreed::Response]
+    def patch(uri, body: nil)
+      uri = URI.parse(uri)
+      req = Net::HTTP::Patch.new(uri)
       req["Authorization"] = "Bearer #{@token}"
       req.body = body.to_json if body
       req["Content-Type"] = "application/json"

--- a/test/degreed/content/courses_test.rb
+++ b/test/degreed/content/courses_test.rb
@@ -188,25 +188,6 @@ module Degreed
         assert_equal 200, response.code
         assert_equal "New Course Updated", response.body.dig("data", "attributes", "title")
       end
-
-      # def test_delete_course_by_id
-      #   create_request = stub_request(:delete, "https://api.degreed.com/api/v2/content/courses/foo")
-      #     .with(
-      #       headers: {
-      #         "Authorization" => "Bearer someoauthtoken"
-      #       }
-      #     )
-      #     .to_return(
-      #       status: 204
-      #     )
-
-      #   response = Degreed::Content::Courses.new(token: "someoauthtoken").destroy(
-      #     id: "foo"
-      #   )
-      #   assert_requested create_request
-      #   assert_equal 204, response.code
-      # end
-
     end
   end
 end

--- a/test/degreed/content/courses_test.rb
+++ b/test/degreed/content/courses_test.rb
@@ -116,7 +116,6 @@ module Degreed
               }
             JSON
           )
-
         response = Degreed::Content::Courses.new(token: "someoauthtoken").all(
           external_id: "1234"
         )
@@ -125,6 +124,89 @@ module Degreed
         assert_equal 200, response.code
         assert_equal "New Course", response.body.dig("data", "attributes", "title")
       end
+
+      def test_update_a_course_by_id
+        create_request = stub_request(:patch, "https://api.degreed.com/api/v2/content/courses/foo")
+          .with(
+            headers: {
+              "Authorization" => "Bearer someoauthtoken",
+              "content-type" => "application/json"
+            },
+            body: {
+              data: {
+                type: "content/courses",
+                id: "foo",
+                attributes: {
+                  title: "New Course Updated",
+                  obsolete: true
+                }
+              }
+            }.to_json
+          )
+          .to_return(
+            status: 200,
+            body: <<~JSON
+              {
+                "data": {
+                  "type": "content/courses",
+                  "id": "foo",
+                  "attributes": {
+                    "provider-code": null,
+                    "external-id": "arstaroisen",
+                    "degreed-url": "https://degreed.com/courses/?d=V9RVZY40PJ",
+                    "title": "New Course Updated",
+                    "summary": "A Summary Updated",
+                    "url": "https://dev.lessonly.com",
+                    "obsolete": false,
+                    "image-url": null,
+                    "language": null,
+                    "duration": 200,
+                    "duration-type": "Seconds",
+                    "cost-units": 0.0,
+                    "cost-unit-type": null,
+                    "format": null,
+                    "difficulty": null,
+                    "video-url": null,
+                    "created-at": "0001-01-01T00:00:00",
+                    "modified-at": "0001-01-01T00:00:00"
+                  },
+                  "links": {
+                    "self": "/content/courses/foo"
+                  }
+                }
+              }
+            JSON
+          )
+
+        response = Degreed::Content::Courses.new(token: "someoauthtoken").update(
+          id: "foo",
+          title: "New Course Updated",
+          obsolete: true
+        )
+
+        assert_requested create_request
+        assert_equal 200, response.code
+        assert_equal "New Course Updated", response.body.dig("data", "attributes", "title")
+      end
+
+      # def test_delete_course_by_id
+      #   create_request = stub_request(:delete, "https://api.degreed.com/api/v2/content/courses/foo")
+      #     .with(
+      #       headers: {
+      #         "Authorization" => "Bearer someoauthtoken"
+      #       }
+      #     )
+      #     .to_return(
+      #       status: 204
+      #     )
+
+      #   response = Degreed::Content::Courses.new(token: "someoauthtoken").destroy(
+      #     id: "foo"
+      #   )
+      #   assert_requested create_request
+      #   assert_equal 204, response.code
+      # end
+
     end
   end
 end


### PR DESCRIPTION
### Why
Need a way to send patch request to update lessons in Degreed.

### What
Added a PATCH req handler and update method in the Degreed client

### Testing
- [ ] Make a curl request with 
```
curl -X POST "https://betatest.degreed.com/oauth/token"
  -H 'Content-Type: application/x-www-form-urlencoded'
  -d 'grant_type=client_credentials&client_id=<id>&client_secret=<secret>&scope=content:read,content:write'
```

The client_id and client_secret can be found in 1password under "Degreed Credentials"

- [ ] copy the returned access_token 

- [ ] In the degreed project directory run `bin/console`

- [ ] set the correct URL for the beta test endpoint before testing a request by running `Degreed.configuration.base_url = "https://api.betatest.degreed.com/api/v2"`

- [ ] res = Degreed::Client.new(token: "copied access token goes here").courses.all # to our ALL courses enpoint
expect response 200 OK
- [ ] res.body["data"].first["attributes"]["obsolete"] # to confirm the oboslete state
expect true or false 
- [ ] res = Degreed::Client.new(token: "copied access token goes here").courses.update(id: "rwrEWz9", obsolete: true) # There is only one lesson currently so the I have included the id. Then set the obsolete value to true or false depending on it's current state
expect response 200 OK
- [ ] res.body["data"].first["attributes"]["obsolete"] # to confirm the oboslete state
expect true or false depending on value sent

Boom!💥 
We should have a working update request!
